### PR TITLE
Optimized SongInit a bit

### DIFF
--- a/src/raspberry_casket.asm
+++ b/src/raspberry_casket.asm
@@ -900,7 +900,9 @@ pre_SongInit:
         move.l  d1,sv_wavelength_table-sv_waveinfo_table(a1)
         btst    #2,wi_flags_b(a3)
         beq.s   .onlythreeocts
-        mulu    #15,d1
+        move.l  d1,d2
+        lsl.l   #4,d1           ; * 16
+        sub.l   d2,d1           ; * 15
         lsr.l   #3,d1           ; * 1.875
 .onlythreeocts
         move.l  d1,sv_wavetotal_table-sv_waveinfo_table(a1)


### PR DESCRIPTION
I just had a quick look at the code and noticed the mul with `15` and figured that it can be replaced with shift + sub instead. I haven't done any testing of this code, but I figured I could just do a PR with it and you use it if you want.

If I done my math right it saves 20 cycles each iteration, but it does add 4 bytes in size.